### PR TITLE
Inlines CSS for production builds

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,6 +1,9 @@
 const pluginPWA = require("eleventy-plugin-pwa");
+const CleanCSS = require("clean-css");
 
 module.exports = function (conf) {
+  conf.addFilter("cssmin", (code) => new CleanCSS({}).minify(code).styles);
+
   conf.setTemplateFormats([
     "html",
     "njk",

--- a/.eleventyignore
+++ b/.eleventyignore
@@ -1,0 +1,1 @@
+src/**/*.11tydata.js

--- a/README.md
+++ b/README.md
@@ -60,3 +60,9 @@ We use Netlify preview builds. To see any branch in a live environment, push the
 ## Code formatting
 
 We format all JavaScript, CSS, and HTML with [Prettier](https://prettier.io). We use the [lint-staged with husky approach](https://prettier.io/docs/en/precommit.html#option-1-lint-stagedhttpsgithubcomokonetlint-staged) to make sure formatting happens for all contributors.
+
+## A note about inline styles
+
+For production builds, we put all CSS in the `head` of each page. This helps avoid layout shift during page load.
+
+During dev builds–with `yarn start`–all CSS is compiled to an external `site.css`. We include that file with a `link` element in the head.

--- a/package.json
+++ b/package.json
@@ -12,12 +12,13 @@
   "private": true,
   "scripts": {
     "start": "eleventy --serve",
-    "build": "eleventy",
+    "build": "ELEVENTY_ENV=production eleventy",
     "lint": "eslint --fix --ext .js",
     "prettier": "prettier --write src/"
   },
   "devDependencies": {
     "@11ty/eleventy": "0.11.0",
+    "clean-css": "4.2.3",
     "eleventy-plugin-pwa": "1.0.8",
     "eslint": "7.5.0",
     "eslint-config-prettier": "6.11.0",

--- a/src/_data/site.js
+++ b/src/_data/site.js
@@ -1,0 +1,3 @@
+module.exports = {
+  environment: process.env.ELEVENTY_ENV,
+};

--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -8,6 +8,8 @@
     {{ title or "ideas42 Venture Studio" }}
   </title>
 
+  <link rel="preload" href="/css/fonts/epilogue.var.woff2" as="font" type="font/woff2" crossorigin>
+
   {% if site.environment === "production" -%}
     {% set inlineCSS -%}
       {% include "../../css/site.njk" %}

--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -8,7 +8,17 @@
     {{ title or "ideas42 Venture Studio" }}
   </title>
 
-  <link rel="stylesheet" href="/css/site.css" />
+  {% if site.environment === "production" -%}
+    {% set inlineCSS -%}
+      {% include "../../css/site.njk" %}
+    {%- endset %}
+
+    <style>
+      {{ inlineCSS | cssmin | safe }}
+    </style>
+  {% else %}
+    <link rel="stylesheet" href="/css/site.css">
+  {%- endif %}
 
   <script>
     /* FIXME: worker turned off during early dev

--- a/src/css/modules/design-tokens/typography.css
+++ b/src/css/modules/design-tokens/typography.css
@@ -1,7 +1,7 @@
 @font-face {
   font-family: "Epilogue";
   font-weight: 100 900;
-  font-sans: swap;
+  font-display: swap;
   font-style: normal;
   src: url("/css/fonts/epilogue.var.woff2") format("woff2");
 }

--- a/src/css/site.11tydata.js
+++ b/src/css/site.11tydata.js
@@ -1,0 +1,8 @@
+module.exports = function () {
+  const permalink =
+    process.env.ELEVENTY_ENV !== "production" ? "css/site.css" : false;
+
+  return {
+    permalink,
+  };
+};

--- a/src/css/site.njk
+++ b/src/css/site.njk
@@ -1,7 +1,3 @@
----
-permalink: css/site.css
----
-
 {% include "./modules/reset.css" %}
 
 {# tokens #}

--- a/yarn.lock
+++ b/yarn.lock
@@ -778,7 +778,7 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
-clean-css@^4.1.11:
+clean-css@4.2.3, clean-css@^4.1.11:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/clean-css/-/clean-css-4.2.3.tgz#507b5de7d97b48ee53d84adb0160ff6216380f78"
   integrity sha512-VcMWDN54ZN/DS+g58HYL5/n4Zrqe8vHJpGA8KdgUXFU4fuP/aHNw8eld9SyEIyabIMJX/0RaY/fplOo5hYLSFA==


### PR DESCRIPTION
For production builds, we put all CSS in the `head` of each page. This helps avoid layout shift during page load.

During dev builds–with `yarn start`–all CSS is compiled to an external `site.css`. We include that file with a `link` element in the head.