### PR TITLE
Fixes CSS Minification + Feature Query Issue

### DIFF
--- a/src/css/modules/design-tokens/typography.css
+++ b/src/css/modules/design-tokens/typography.css
@@ -68,11 +68,13 @@ html {
   line-height: 1.7;
 }
 
-@supports (font-variation-settings: "wdth" 115) {
+/* clean-css ignore:start */
+@supports (font-variation-settings: "wdth" 285) {
   html {
     --font-sans: "epilogue-var", helvetica, sans-serif;
   }
 }
+/* clean-css ignore:end */
 
 h1,
 h2,


### PR DESCRIPTION
I documented the underlying issue with the 3rd party CSS minifier here https://github.com/jakubpawlowicz/clean-css/issues/1125

This was causing us to never load the variable font, even when browsers supported it because the `@supports` condition was being made invalid when the quotes got stripped.

This PR hides the `@support` block from the minifier