### PR TITLE
Fixes QA Session Dates

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -10,7 +10,7 @@ const slugify = (str) =>
 module.exports = function (conf) {
   conf.addFilter("cssmin", (code) => new CleanCSS({}).minify(code).styles);
   conf.addShortcode("dateFormat", (dateStr, frmt = "DDD 'at' t ZZZZ") =>
-    DateTime.fromISO(dateStr).toFormat(frmt)
+    DateTime.fromISO(dateStr, { zone: "America/New_York" }).toFormat(frmt)
   );
   conf.addShortcode("headingAnchor", (level, text, id) => {
     const finalId = id ? id : slugify(text);

--- a/src/_data/qaSessions.json
+++ b/src/_data/qaSessions.json
@@ -1,10 +1,10 @@
 [
   {
     "url": "https://tinyurl.com/VSPoption1",
-    "datetime": "2020-10-10T14:00:00-04:00"
+    "datetime": "2020-10-10T14:00:00"
   },
   {
     "url": "https://tinyurl.com/VSPoption2",
-    "datetime": "2020-10-15T20:00:00-04:00"
+    "datetime": "2020-10-15T20:00:00"
   }
 ]


### PR DESCRIPTION
We were setting the timezone offset in the date strings for QA sessions. When this built on the Netlify machine, UTC times were displayed. Locally, was the correct time zone, because my machine is in EDT. Even when you add a offset to a date string, Luxon still creates dates in UTC.

In this we:

* Removes offsets from qa session date strings
* Explicitly sets a zone for Luxon `DateTime.fromISO`