### PR TITLE
Adds tags field to sign up form

### DIFF
--- a/src/_includes/components/footer.njk
+++ b/src/_includes/components/footer.njk
@@ -16,6 +16,7 @@
           <div class="field--connected-btn">
             <input id="newsletter-email" type="email" name="email" 
               placeholder="name@example.com" autocapitalize="off" required />
+            <input type="hidden" name="tags" value="Web Sign up"/>
             <button type="submit" class="btn">Subscribe</button>
           </div>
           <p class="form-success hidden">


### PR DESCRIPTION
Adds a `tags` field with a value of "Web Sign up" for all sign ups. We use the "Web Sign up" tag in Buttondown. Hoping this field will be available in the exported CSV so tags will stay put when we import to Buttondown