### PR TITLE
Updates Copy and URL for VSP Banner link

### DIFF
--- a/src/_includes/components/banner.njk
+++ b/src/_includes/components/banner.njk
@@ -1,8 +1,8 @@
 <header class="banner g-padded">
   {% if not noCohortCta %}
-  <a data-fathom-goal="INHY8CAZ" class="banner__cta" href="/ventures-for-shared-prosperity/apply/">
+  <a data-fathom-goal="INHY8CAZ" class="banner__cta" href="/ventures-for-shared-prosperity/">
     <img src="/images/cohort-mark.svg" alt="" height="36" width="36"> 
-    <span><strong>Apply to join our next cohort as an entrepreneur</strong></span>
+    <span>Learn about our first cohort <strong>Ventures for Shared Prosperity</strong></span>
     <span class="btn__arrow">{% include "../../images/graphic-arrow-btn.svg" %}</span>
   </a>
   {% endif %}


### PR DESCRIPTION
**This PR**

- Changes the copy of the VSP Banner link away from "apply" language, to more general "learn"
- Changes the url of the VSP Banner link to the VSP landing page, instead of the apply page

View the changes at https://deploy-preview-86--ideas42ventures.netlify.app/

**Why?**

1. I think the "apply" language is causing folks to not understand that they can follow the link to find general information about VSP, and think it's a direct link to an application form
1. I think directing folks to the VSP landing is better for surfacing the other VSP information like Focus Area and What We Do, **I do not think** we'll lose potential applicants by sending them to the landing first, and requiring them to get to apply. If they're motivated enough to apply, I think they'll get there.
1. We have existing link directly to Apply in the global nav

**Anecdotes**

- We've had a few folks visit the site and say they had trouble getting to the Focus Area and What We Provide pages
- Those folks said that they thought the VSP banner was going to take them to an application form, not general info

So no concrete data on it, but a few folks. I also think that a more general language/link is the better information arch for this.