### PR TITLE
Change buttondown to mailchimp for email signup forms

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,8 @@ We still want to track how our site is being used, so instead, we use the privac
 
 ### Email subscription form
 
-We use [Buttondown](https://buttondown.email/) to handle the form submission.
+We use [Mailchimp](https://mailchimp.com/) to handle the form submission.
 
-- Form submissions are stored in the subscriber tab in the Buttondown dashboard.
-- The `env` variable for the Buttondown is set in the Netlify environment UI.
-- We handle browsers that have JS disabled with redirects to static pages.
 
 ## Contributing
 

--- a/src/_includes/components/apply-note.njk
+++ b/src/_includes/components/apply-note.njk
@@ -10,7 +10,7 @@
     <!-- Begin Mailchimp Signup Form -->
     <div id="mc_embed_signup">
     <form
-      action="https://ideas42ventures.us1.list-manage.com/subscribe/post?u=f28b0f7c2bec71e9dc4a14f7f&amp;id=69350d4819"
+      action="https://ideas42ventures.us1.list-manage.com/subscribe/post?u=f28b0f7c2bec71e9dc4a14f7f&amp;id=69350d4819&amp;SIGNUP=apply-page"
       method="post"
       id="mc-embedded-subscribe-form"
       name="mc-embedded-subscribe-form"

--- a/src/_includes/components/apply-note.njk
+++ b/src/_includes/components/apply-note.njk
@@ -24,8 +24,8 @@
             We anticipate beginning recruitment for our next cohort in <b>mid 2021</b>.
             Sign up for our newsletter for updates.
           </legend>
-          <div class="mc-field-group">
-            <label for="mce-EMAIL">Email Address </label>
+          <div class="mc-field-group field-group">
+            <label class="newsletter-label--apply" for="mce-EMAIL">Email Address </label>
             <input
               type="email"
               value=""

--- a/src/_includes/components/apply-note.njk
+++ b/src/_includes/components/apply-note.njk
@@ -1,32 +1,53 @@
 <div class="card grid--max-2">
   <header class="card__intro">
     <p>
-      <strong class="card__title">Applications closed</strong> 
+      <strong class="card__title">Applications closed</strong>
       Applications for this cohort closed on Oct 25 2020. We’ve completed the interview process and
       will be making offers soon. If you submitted an application, thank you!
     </p>
   </header>
   <div class="card__body card__body--bordered">
-    <form class="newsletter-form" name="newsletter" action="/.netlify/functions/newsletter-submission" 
-      method="post">
-      <fieldset>
-        <legend class="legend--text font-size-1">
-          We anticipate beginning recruitment for our next cohort in <b>mid 2021</b>.
-          Sign up for our newsletter for updates.
-        </legend>
-
-        <label for="newsletter-email--apply">Email address</label>
-        <input id="newsletter-email--apply" class="input--full" type="email" name="email" 
-          placeholder="name@example.com" autocapitalize="off" autocorrect="off" required />
-        <input type="hidden" name="tags" value="Web Sign up,Apply page"/> 
-        <button type="submit" class="btn">Subscribe</button>
-
-        <p class="form__msg hidden"></p>
-      </fieldset>
-
-      <p class="hidden" hidden>
-        <label>Don’t fill this out if you're human: <input name="bot-field"></label>
-      </p>
+    <!-- Begin Mailchimp Signup Form -->
+    <div id="mc_embed_signup">
+    <form
+      action="https://ideas42ventures.us1.list-manage.com/subscribe/post?u=f28b0f7c2bec71e9dc4a14f7f&amp;id=69350d4819"
+      method="post"
+      id="mc-embedded-subscribe-form"
+      name="mc-embedded-subscribe-form"
+      class="validate newsletter-form"
+      target="_blank"
+      novalidate
+    >
+      <div id="mc_embed_signup_scroll">
+        <fieldset class="newsletter-fields">
+          <legend class="legend--text font-size-1">
+            We anticipate beginning recruitment for our next cohort in <b>mid 2021</b>.
+            Sign up for our newsletter for updates.
+          </legend>
+          <div class="mc-field-group">
+            <label for="mce-EMAIL">Email Address </label>
+            <input
+              type="email"
+              value=""
+              name="EMAIL"
+              class="required email input input--full"
+              id="mce-EMAIL"
+              placeholder="name@example.com"
+              autocapitalize="off"
+              autocorrect="off"
+              required
+            >
+          </div>
+          <div id="mce-responses" class="clear">
+            <div class="response" id="mce-error-response" style="display:none"></div>
+            <div class="response" id="mce-success-response" style="display:none"></div>
+          </div>    <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
+          <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_f28b0f7c2bec71e9dc4a14f7f_69350d4819" tabindex="-1" value=""></div>
+          <input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="button btn btn--full">
+        </fieldset>
+      </div>
     </form>
+    </div>
+    <!--End mc_embed_signup-->
   </div>
 </div>

--- a/src/_includes/components/footer.njk
+++ b/src/_includes/components/footer.njk
@@ -5,7 +5,7 @@
     <form
       class="newsletter-form g-max-2 validate"
       name="newsletter"
-      action="https://ideas42ventures.us1.list-manage.com/subscribe/post?u=f28b0f7c2bec71e9dc4a14f7f&amp;id=69350d4819"
+      action="https://ideas42ventures.us1.list-manage.com/subscribe/post?u=f28b0f7c2bec71e9dc4a14f7f&amp;id=69350d4819&amp;SIGNUP=footer"
       method="post"
       id="mc-embedded-subscribe-form"
       name="mc-embedded-subscribe-form"

--- a/src/_includes/components/footer.njk
+++ b/src/_includes/components/footer.njk
@@ -41,7 +41,7 @@
             <div style="position: absolute; left: -5000px;" aria-hidden="true">
               <input type="text" name="b_f28b0f7c2bec71e9dc4a14f7f_69350d4819" tabindex="-1" value="">
             </div>
-            <input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="button btn">
+            <input id="submit-btn" type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="button btn">
           </div>
         </div>
 

--- a/src/_includes/components/footer.njk
+++ b/src/_includes/components/footer.njk
@@ -12,16 +12,17 @@
       target="_blank"
       novalidate
     >
-      <fieldset id="mc_embed_signup_scroll">
-        <div class="mc-field-group">
+      <div id="mc_embed_signup_scroll">
+        <fieldset class="mc-field-group">
           <legend>
             Get updates
           </legend>
           <p class="newsletter-info g-max-1-half">
             We share brief updates about our process and progress. <strong>Never spam</strong>.
           </p>
-          <label for="mce-EMAIL">Email Address </label>
-          <div class="field--connected-btn">
+
+          <div class="mce-field-group field--connected-btn">
+            <label for="mce-EMAIL">Email Address </label>
             <input
               type="email"
               value=""
@@ -43,9 +44,9 @@
             </div>
             <input id="submit-btn" type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="button btn">
           </div>
-        </div>
+        </fieldset>
 
-      </fieldset>
+      </div>
     </form>
     </div>
 <!--End mc_embed_signup-->

--- a/src/_includes/components/footer.njk
+++ b/src/_includes/components/footer.njk
@@ -1,35 +1,54 @@
 <footer class="contentinfo">
   <div class="contentinfo__contents standard-restricted-width">
-    <form class="newsletter-form g-max-2" name="newsletter" action="/.netlify/functions/newsletter-submission"
+    <!-- Begin Mailchimp Signup Form -->
+    <div id="mc_embed_signup">
+    <form
+      class="newsletter-form g-max-2 validate"
+      name="newsletter"
+      action="https://ideas42ventures.us1.list-manage.com/subscribe/post?u=f28b0f7c2bec71e9dc4a14f7f&amp;id=69350d4819"
       method="post"
-      id="newsletter-form">
-      <fieldset>
-        <legend>
-          Get updates
-        </legend>
-        <p class="newsletter-info g-max-1-half">
-          We share brief updates about our process and progress. <strong>Never spam</strong>.
-        </p>
-
-        <div>
-          <label for="newsletter-email">Email address</label>
+      id="mc-embedded-subscribe-form"
+      name="mc-embedded-subscribe-form"
+      target="_blank"
+      novalidate
+    >
+      <fieldset id="mc_embed_signup_scroll">
+        <div class="mc-field-group">
+          <legend>
+            Get updates
+          </legend>
+          <p class="newsletter-info g-max-1-half">
+            We share brief updates about our process and progress. <strong>Never spam</strong>.
+          </p>
+          <label for="mce-EMAIL">Email Address </label>
           <div class="field--connected-btn">
-            <input id="newsletter-email" type="email" name="email"
+            <input
+              type="email"
+              value=""
+              name="EMAIL"
+              class="required email input"
+              id="mce-EMAIL"
               placeholder="name@example.com"
               autocomplete="off"
-              autocapitalize="off" required />
-
-        <input type="hidden" name="tags" value="Web Sign up"/>
-            <button type="submit" class="btn">Subscribe</button>
+              autocapitalize="off"
+              require
+            >
+            <div id="mce-responses" class="clear">
+              <div class="response" id="mce-error-response" style="display:none"></div>
+              <div class="response" id="mce-success-response" style="display:none"></div>
+            </div>
+            <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
+            <div style="position: absolute; left: -5000px;" aria-hidden="true">
+              <input type="text" name="b_f28b0f7c2bec71e9dc4a14f7f_69350d4819" tabindex="-1" value="">
+            </div>
+            <input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="button btn">
           </div>
-          <p class="form__msg hidden"></p>
         </div>
-      </fieldset>
 
-      <p class="hidden" hidden>
-        <label>Don’t fill this out if you're human: <input name="bot-field"></label>
-      </p>
+      </fieldset>
     </form>
+    </div>
+<!--End mc_embed_signup-->
 
     <nav class="contentinfo__nav">
       <a href="/about">About us</a>

--- a/src/css/modules/components/button.css
+++ b/src/css/modules/components/button.css
@@ -1,4 +1,6 @@
-.btn {
+.btn,
+.field--connected-btn > .btn,
+.newsletter-fields > input .btn {
   --padding-v: 0.7em;
   --padding-h: 1.5em;
   --color: var(--color-accent-active);

--- a/src/css/modules/components/newsletter-form.css
+++ b/src/css/modules/components/newsletter-form.css
@@ -8,7 +8,7 @@
   padding: 0;
 }
 
-.newsletter-form legend + label {
+.newsletter-form .field-group {
   margin-top: var(--g-row);
 }
 
@@ -22,7 +22,8 @@
   margin-top: 0;
 }
 
-.newsletter-form label {
+.newsletter-form label,
+.newsletter-label--apply {
   display: block;
   font-size: var(--font-size-1);
   font-weight: 600;

--- a/src/css/modules/components/newsletter-form.css
+++ b/src/css/modules/components/newsletter-form.css
@@ -68,7 +68,7 @@ input {
   color: rgba(255, 255, 255, 0.7);
 }
 
-.field--connected-btn > input .btn {
+.field--connected-btn > #submit-btn {
   --border-radius: 0 0 8px 8px;
   width: 100%;
 }
@@ -89,7 +89,7 @@ input {
     --border-radius: 8px 0 0 8px;
   }
 
-  .field--connected-btn > input .btn {
+  .field--connected-btn > #submit-btn {
     --border-radius: 0 8px 8px 0;
     --padding-h: 1em;
     padding: var(--padding-v) var(--padding-h);

--- a/src/css/modules/components/newsletter-form.css
+++ b/src/css/modules/components/newsletter-form.css
@@ -49,12 +49,13 @@ input {
   width: 100%;
 }
 
-.input--full ~ .btn {
+.input--full ~ .btn,
+.btn--full {
   margin-top: var(--g-row);
   width: 100%;
 }
 
-.field--connected-btn input {
+.field--connected-btn > .input {
   --border-radius: 8px 8px 0 0;
   background-color: rgba(255, 255, 255, 0.08);
   border: 0;
@@ -63,11 +64,11 @@ input {
   flex: 1;
 }
 
-.field--connected-btn input::placeholder {
+.field--connected-btn > .input::placeholder {
   color: rgba(255, 255, 255, 0.7);
 }
 
-.field--connected-btn .btn {
+.field--connected-btn > input .btn {
   --border-radius: 0 0 8px 8px;
   width: 100%;
 }
@@ -84,11 +85,11 @@ input {
 }
 
 @media (min-width: 40.625em) {
-  .field--connected-btn input {
+  .field--connected-btn > .input {
     --border-radius: 8px 0 0 8px;
   }
 
-  .field--connected-btn .btn {
+  .field--connected-btn > input .btn {
     --border-radius: 0 8px 8px 0;
     --padding-h: 1em;
     padding: var(--padding-v) var(--padding-h);

--- a/src/js/site.js
+++ b/src/js/site.js
@@ -19,66 +19,6 @@ function closeMobileMenu() {
 }
 
 window.addEventListener("DOMContentLoaded", () => {
-  function showFormSuccess(form, msgEl, text) {
-    form.reset();
-    msgEl.innerHTML = text;
-    msgEl.classList.remove("hidden");
-  }
-
-  function showFormError(msgEl, text) {
-    msgEl.innerHTML = text;
-    msgEl.classList.remove("hidden");
-  }
-
-  function toggleFormBtn(btn, state = "on") {
-    if (state === "off") {
-      btn.classList.add("btn--disabled");
-      btn.innerText = "Subscribing....";
-      return;
-    }
-    btn.classList.remove("btn--disabled");
-    btn.innerText = "Subscribe";
-  }
-
-  [...document.querySelectorAll(".newsletter-form")].forEach((form) => {
-    const msgEl = form.querySelector(".form__msg");
-    const btn = form.querySelector("button[type=submit]");
-
-    form.addEventListener("submit", (e) => {
-      e.preventDefault();
-      const url = form.getAttribute("action");
-      const body = new URLSearchParams(new FormData(form)).toString();
-
-      toggleFormBtn(btn, "off");
-
-      fetch(url, {
-        method: "post",
-        body,
-      })
-        .then((res) => {
-          toggleFormBtn(btn);
-          return res.json();
-        })
-        .then((data) => {
-          if (data.statusCode === 400) {
-            throw new Error(data.message);
-          }
-          showFormSuccess(form, msgEl, data.message);
-          return;
-        })
-        .catch((err) => {
-          if (err instanceof SyntaxError) {
-            showFormError(
-              msgEl,
-              "Sorry, something went wrong on our end. Please try again"
-            );
-          } else {
-            showFormError(msgEl, err);
-          }
-        });
-    });
-  });
-
   try {
     [...document.querySelectorAll("a[data-fathom-goal]")].forEach((a) => {
       a.addEventListener("click", (e) => {


### PR DESCRIPTION
I had to modify some selectors to be a lot more specific because of how the submit button is now an input not a button. If there are better ways to do it (I feel like there probably are, but a bunch of things I tried did not work), let me know. 

Also, I'm unclear on what needs to be different between the form that is in the footer and the form on the entrepreneur page.

Suggestions for what link/info to put in the README are welcome; I don't feel like I know enough about MailChimp to be very specific.